### PR TITLE
Hotfix 

### DIFF
--- a/abdata/abelem.as
+++ b/abdata/abelem.as
@@ -78,7 +78,7 @@
 	if ( (vtype(0) == vartype_double || vtype(0) == vartype_int) && (vtype(1) == vartype_double || vtype(1) == vartype_int) ) {
 		value = double(lhs) - rhs
 		return int(value / absf(value))
-	} elsif ( vtype(0) != vtype(1) ) {
+	} else : if ( vtype(0) != vtype(1) ) {
 		return vtype(0) - vtype(1)
 	} else {
 		return lhs != rhs

--- a/abdata/all.as
+++ b/abdata/all.as
@@ -5,9 +5,9 @@
 
 #include "abelem.as"
 #include "list.as"
-#include "deque.as"
+;#include "deque.as"
 #include "stack.as"
-#include "queue.as"
+;#include "queue.as"
 #include "tnode.as"
 #include "pair.as"
 #include "unor.as"


### PR DESCRIPTION
- abelem.asのシンタックスエラーを修正
- all.asについて、deque.asとqueue.asが存在しないため、コメントアウト
